### PR TITLE
Set player to sender.

### DIFF
--- a/src/main/java/com/iConomy/entity/Players.java
+++ b/src/main/java/com/iConomy/entity/Players.java
@@ -57,12 +57,18 @@ public class Players implements Listener {
      * instances of the same help lines.
      */
     private void getMoneyHelp(CommandSender sender) {
+        boolean isPlayer = sender instanceof Player;
+        
         Messaging.send(sender, "`y ");
         Messaging.send(sender, "`w iConomy (`r" + Constants.Codename + "`w)");
         Messaging.send(sender, "`y ");
         Messaging.send(sender, "`w [] Required, () Optional");
         Messaging.send(sender, " ");
-        Messaging.send(sender, "`G  /money `y Check your balance");
+        
+        if(isPlayer){
+            Messaging.send(sender, "`G  /money `y Check your balance");
+        }
+        
         Messaging.send(sender, "`G  /money `g? `y For help & Information");
 
         if (iConomy.hasPermissions(sender, "iConomy.rank")) {
@@ -124,12 +130,18 @@ public class Players implements Listener {
      * instances of the same help lines.
      */
     private void getBankHelp(CommandSender sender) {
+        boolean isPlayer = sender instanceof Player;
+        
         Messaging.send(sender, "`y ");
         Messaging.send(sender, "`w iConomy (`r" + Constants.Codename + "`w)");
         Messaging.send(sender, "`y ");
         Messaging.send(sender, "`w [] Required, () Optional");
         Messaging.send(sender, " ");
-        Messaging.send(sender, "`G  /bank `y Check your bank accounts");
+       
+        if(isPlayer){
+            Messaging.send(sender, "`G  /bank `y Check your bank accounts");
+        }
+        
         Messaging.send(sender, "`G  /bank `g? `y For help & Information");
 
         if (iConomy.hasPermissions(sender, "iConomy.bank.list")) {
@@ -1048,7 +1060,7 @@ public class Players implements Listener {
                     		"help", "?", "create", "-c", "remove", "-r", "set", "-s",
                     		"send", "->", "deposit", "-d", "join", "-j", "leave", "-l"
                     })) {
-                        getBankHelp(player);
+                        getBankHelp(sender);
                         return true;
                     }
                     if (!iConomy.hasPermissions(sender, "iConomy.bank.access")) {
@@ -1474,7 +1486,7 @@ public class Players implements Listener {
                     }
 
                     if (Misc.is(split[1], new String[] { "help", "?", "grant", "-g", "reset", "-x", "set", "-s", "pay", "-p", "create", "-c", "remove", "-v", "hide", "-h" })) {
-                        getMoneyHelp(player);
+                        getMoneyHelp(sender);
                         return true;
                     }
                     if (!iConomy.hasPermissions(sender, "iConomy.access")) {
@@ -1722,7 +1734,7 @@ public class Players implements Listener {
                     return true;
             }
 
-            getMoneyHelp(player);
+            getMoneyHelp(sender);
         }
 
         return false;


### PR DESCRIPTION
Resolves issue running /money <args> or /bank <args>

I came across this error while using `/money ?` or `/money help` in console

```
[07:54:55] [Server thread/INFO]: Cannot show balance without an organism.
[07:54:56] [Server thread/WARN]: Unexpected exception while parsing console command "money help"
org.bukkit.command.CommandException: Unhandled exception executing command 'money' in plugin iConomy v5.15
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:155) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R2.CraftServer.dispatchCommand(CraftServer.java:929) ~[paper-1.19.3.jar:git-Paper-373]
	at org.bukkit.craftbukkit.v1_19_R2.CraftServer.dispatchServerCommand(CraftServer.java:892) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:494) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:441) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1397) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-373]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.command.CommandSender.sendMessage(String)" because "sender" is null
	at com.iConomy.util.Messaging.send(Messaging.java:136) ~[iConomy-5.15.jar:?]
	at com.iConomy.entity.Players.getMoneyHelp(Players.java:60) ~[iConomy-5.15.jar:?]
	at com.iConomy.entity.Players.onPlayerCommand(Players.java:1477) ~[iConomy-5.15.jar:?]
	at com.iConomy.iConomy.onCommand(iConomy.java:252) ~[iConomy-5.15.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	... 9 more
[08:06:09] [Server thread/WARN]: Unexpected exception while parsing console command "money ?"
org.bukkit.command.CommandException: Unhandled exception executing command 'money' in plugin iConomy v5.15
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:155) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_19_R2.CraftServer.dispatchCommand(CraftServer.java:929) ~[paper-1.19.3.jar:git-Paper-373]
	at org.bukkit.craftbukkit.v1_19_R2.CraftServer.dispatchServerCommand(CraftServer.java:892) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:494) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:441) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1397) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1173) ~[paper-1.19.3.jar:git-Paper-373]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-373]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "org.bukkit.command.CommandSender.sendMessage(String)" because "sender" is null
	at com.iConomy.util.Messaging.send(Messaging.java:136) ~[iConomy-5.15.jar:?]
	at com.iConomy.entity.Players.getMoneyHelp(Players.java:60) ~[iConomy-5.15.jar:?]
	at com.iConomy.entity.Players.onPlayerCommand(Players.java:1477) ~[iConomy-5.15.jar:?]
	at com.iConomy.iConomy.onCommand(iConomy.java:252) ~[iConomy-5.15.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
	... 9 more
```